### PR TITLE
Fix dot product return type and add validation test

### DIFF
--- a/src/include/refx/geometry/vector.h
+++ b/src/include/refx/geometry/vector.h
@@ -887,7 +887,7 @@ Vector3D<Frame1, T> cross(const Vector3D<Frame1, T>& a, const Vector3D<Frame2, T
  * A compile-time error will occur if `a` and `b` have different frame types.
  */
 template <typename Frame1, typename Frame2, typename T>
-Vector3D<Frame1, T> dot(const Vector3D<Frame1, T>& a, const Vector3D<Frame2, T>& b) {
+T dot(const Vector3D<Frame1, T>& a, const Vector3D<Frame2, T>& b) {
     internal::FrameValidator<Frame1, Frame2>::validate();
     internal::FrameDirectionalAxisValidator<Frame1>::validate();
     return T(a.x() * b.x() + a.y() * b.y() + a.z() * b.z());

--- a/src/include/refx/geometry/vector.h
+++ b/src/include/refx/geometry/vector.h
@@ -878,8 +878,8 @@ Vector3D<Frame1, T> cross(const Vector3D<Frame1, T>& a, const Vector3D<Frame2, T
  *
  * @tparam Frame The shared reference frame of the vectors.
  * @tparam T The scalar type.
- * @param a The left-hand side vector in the cross product (`a x b`).
- * @param b The right-hand side vector in the cross product (`a x b`).
+ * @param a The left-hand side vector in the dot product (`a · b`).
+ * @param b The right-hand side vector in the dot product (`a · b`).
  * @return a scalar representing the dot product `a . b`.
  * @warning This operation is only physically meaningful for vectors in Cartesian
  * reference frames (e.g., `NED`, `FRD`, `ECEF`). Using it on non-Cartesian types

--- a/test/include/geometry/test_vector_operations.hpp
+++ b/test/include/geometry/test_vector_operations.hpp
@@ -1,0 +1,46 @@
+#ifndef _GEOMETRY_TEST_VECTOR_OPERATIONS_
+#define _GEOMETRY_TEST_VECTOR_OPERATIONS_
+#include <gtest/gtest.h>
+
+// Include all the necessary headers from your library
+#include "../tol.h"
+#include "refx/geometry.h"
+
+// Use a consistent namespace for tests
+namespace refx {
+namespace testing {
+
+/**
+ * @test Test fixture for Vector3D arithmetic operations.
+ * This suite verifies the correctness of vector operations
+ */
+class VectorOperationsTest : public ::testing::Test {
+   protected:
+    // Define some common vectors for testing
+    Vector3D<ned, double> v1_ned{3.0, 4.0, 0.0};  // magnitude = 5.0
+    Vector3D<ned, double> v2_ned{1.0, 0.0, 0.0};  // unit vector in north direction
+    Vector3D<ned, double> v3_ned{0.0, 1.0, 0.0};  // unit vector in east direction
+};
+
+// Test that dot product returns a scalar value and is computed correctly
+TEST_F(VectorOperationsTest, DotProductScalarResult) {
+    // Compute dot product
+    double dot_result = dot(v1_ned, v2_ned);
+
+    // Verify the mathematical result: (3,4,0) · (1,0,0) = 3
+    EXPECT_NEAR(dot_result, 3.0, HARD_TOLERANCE);
+
+    // Test with perpendicular vectors (dot product should be 0)
+    double perpendicular_dot = dot(v2_ned, v3_ned);
+    EXPECT_NEAR(perpendicular_dot, 0.0, HARD_TOLERANCE);
+
+    // Test with parallel vectors (dot product should be product of magnitudes)
+    Vector3D<ned, double> v4_ned{2.0, 0.0, 0.0};  // parallel to v2_ned
+    double parallel_dot = dot(v2_ned, v4_ned);
+    EXPECT_NEAR(parallel_dot, 2.0, HARD_TOLERANCE);  // 1 * 2 = 2
+}
+
+}  // namespace testing
+}  // namespace refx
+
+#endif /* _GEOMETRY_TEST_VECTOR_OPERATIONS_ */

--- a/test/test_example.cpp
+++ b/test/test_example.cpp
@@ -6,6 +6,7 @@
 #include "include/geometry/test_rotation.hpp"
 #include "include/geometry/test_transformation.hpp"
 #include "include/geometry/test_vector_coordinate.hpp"
+#include "include/geometry/test_vector_operations.hpp"
 
 //
 // ---------------------- Earth Model Testing ----------------------


### PR DESCRIPTION
- Fix a bug where dot() returned Vector3D instead of scalar T
- Correct the documentation for the dot() function which incorrectly referenced "cross product (a x b)" instead of "dot product (a · b)"
- New Test file (test_vector_operations.hpp) for vector operations tests
- Add DotProductScalarResult test validating dot product operations.