### PR TITLE
fix: add _USE_MATH_DEFINES for MSVC compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU
     add_compile_options(-Wall)
 endif()
 
+# Enable math constants (M_PI, M_PI_2, etc.) on MSVC/Windows
+if (MSVC OR WIN32)
+    add_compile_definitions(_USE_MATH_DEFINES)
+endif()
+
 # Enable/Disable Eigen Detection
 set(REFX_ENABLE_EIGEN_DETECTION ON CACHE BOOL "Enable the dection of Eigen3 Library")
  


### PR DESCRIPTION
Add `_USE_MATH_DEFINES` compile definition globally in CMakeLists.txt to enable M_PI and M_PI_2 constants on Windows/MSVC. These are non-standard extensions that require explicit enabling on MSVC, causing compilation  failures without this define.